### PR TITLE
Wishbone improvements

### DIFF
--- a/src/main/scala/DMAController/Bus/WishboneMaster.scala
+++ b/src/main/scala/DMAController/Bus/WishboneMaster.scala
@@ -24,6 +24,7 @@ SOFTWARE.
 package DMAController.Bus
 
 import chisel3._
+import chisel3.util._
 
 class WishboneMaster(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   /* data */
@@ -33,7 +34,7 @@ class WishboneMaster(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   val cyc_o = Output(Bool())
   val stb_o = Output(Bool())
   val we_o = Output(Bool())
-  val adr_o = Output(UInt(addrWidth.W))
+  val adr_o = Output(UInt((addrWidth - log2Ceil(dataWidth / 8)).W))
   val sel_o = Output(UInt((dataWidth / 8).W))
   val ack_i = Input(Bool())
   val stall_i = Input(Bool())

--- a/src/main/scala/DMAController/Bus/WishboneSlave.scala
+++ b/src/main/scala/DMAController/Bus/WishboneSlave.scala
@@ -24,6 +24,7 @@ SOFTWARE.
 package DMAController.Bus
 
 import chisel3._
+import chisel3.util._
 
 class WishboneSlave(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   /* data */
@@ -33,7 +34,7 @@ class WishboneSlave(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   val cyc_i = Input(Bool())
   val stb_i = Input(Bool())
   val we_i = Input(Bool())
-  val adr_i = Input(UInt(addrWidth.W))
+  val adr_i = Input(UInt((addrWidth - log2Ceil(dataWidth / 8)).W))
   val sel_i = Input(UInt((dataWidth / 8).W))
   val ack_o = Output(Bool())
   val stall_o = Output(Bool())

--- a/src/main/scala/DMAController/Frontend/WishboneCSR.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneCSR.scala
@@ -40,25 +40,20 @@ class WishboneCSR(addrWidth : Int) extends Module{
   val state = RegInit(sIdle)
 
   val ack  = RegInit(false.B)
-  val write = RegInit(false.B)
-  val read = RegInit(false.B)
 
   val valid = WireInit(io.ctl.stb_i & io.ctl.cyc_i)
 
   switch(state){
     is(sIdle){
       ack := false.B
-      write := false.B
-      read := false.B
       when(io.ctl.stb_i & io.ctl.cyc_i){
         state := sAck
+        ack := true.B
       }
     }
     is(sAck){
+      ack := false.B
       state := sIdle
-      ack := true.B
-      write := io.ctl.we_i
-      read := !io.ctl.we_i
     }
   }
 
@@ -66,10 +61,10 @@ class WishboneCSR(addrWidth : Int) extends Module{
   io.ctl.err_o := false.B
 
   io.ctl.ack_o := ack
-  io.bus.write := write
-  io.bus.read := read
+  io.bus.write := ack & io.ctl.we_i
+  io.bus.read := ack & !io.ctl.we_i
 
   io.bus.dataOut := io.ctl.dat_i
   io.ctl.dat_o := io.bus.dataIn
-  io.bus.addr := io.ctl.adr_i(5, 2)
+  io.bus.addr := io.ctl.adr_i
 }

--- a/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedReader.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedReader.scala
@@ -57,7 +57,7 @@ class WishboneClassicPipelinedReader(val addrWidth : Int, val dataWidth : Int) e
   io.bus.dat_o := 0.U
   io.bus.we_o := false.B
   io.bus.sel_o := ~0.U((dataWidth / 8).W)
-  io.bus.adr_o := adr
+  io.bus.adr_o := adr(addrWidth - 1, log2Ceil(dataWidth / 8))
   io.bus.cyc_o := cyc
   io.bus.stb_o := stb
 

--- a/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedWriter.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedWriter.scala
@@ -57,7 +57,7 @@ class WishboneClassicPipelinedWriter(val addrWidth : Int, val dataWidth : Int) e
 
   io.bus.we_o := true.B
   io.bus.sel_o := ~0.U((dataWidth / 8).W)
-  io.bus.adr_o := adr
+  io.bus.adr_o := adr(addrWidth - 1, log2Ceil(dataWidth / 8))
   io.bus.cyc_o := cyc
   io.bus.stb_o := stb
 

--- a/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
@@ -41,8 +41,8 @@ class WishboneClassicReader(val addrWidth : Int, val dataWidth : Int) extends Mo
 
   val stbCnt = RegInit(0.U(addrWidth.W))
   val adr = RegInit(0.U(addrWidth.W))
-  val cyc = WireInit(stbCnt =/= 0.U)
   val stb = WireInit(stbCnt =/= 0.U && io.dataOut.ready)
+  val cyc = WireInit(stb)
   val ack = WireInit(io.bus.ack_i)
 
   val ready = WireInit(cyc && stb && ack)

--- a/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
@@ -55,7 +55,7 @@ class WishboneClassicReader(val addrWidth : Int, val dataWidth : Int) extends Mo
   io.bus.dat_o := 0.U
   io.bus.we_o := false.B
   io.bus.sel_o := ~0.U((dataWidth / 8).W)
-  io.bus.adr_o := adr
+  io.bus.adr_o := adr(addrWidth - 1, log2Ceil(dataWidth / 8))
   io.bus.cyc_o := cyc
   io.bus.stb_o := stb
 

--- a/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
@@ -57,7 +57,7 @@ class WishboneClassicWriter(val addrWidth : Int, val dataWidth : Int) extends Mo
 
   io.bus.we_o := true.B
   io.bus.sel_o := ~0.U((dataWidth / 8).W)
-  io.bus.adr_o := adr
+  io.bus.adr_o := adr(addrWidth - 1, log2Ceil(dataWidth / 8))
   io.bus.cyc_o := cyc
   io.bus.stb_o := stb
 

--- a/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
@@ -43,8 +43,8 @@ class WishboneClassicWriter(val addrWidth : Int, val dataWidth : Int) extends Mo
 
   val stbCnt = RegInit(0.U(addrWidth.W))
   val adr = RegInit(0.U(addrWidth.W))
-  val cyc = WireInit(stbCnt =/= 0.U)
   val stb = WireInit(stbCnt =/= 0.U && valid)
+  val cyc = WireInit(stb)
   val ack = WireInit(io.bus.ack_i)
 
   val ready = WireInit(cyc && stb && ack)


### PR DESCRIPTION
During tests in Litex several issues related to Wishbone buses surfaced:
- Control bus could send `ack` twice.
- Control bus used wrong bits of the address to select register to access
- Reader/Writer tried to hold the bus even when internal FIFO was full/empty which resulted in deadlocks
- Address bus contained full 32-bit addresses but it should only contain upper 30 bits (in standard configuration with 32-bit address and 32-bit data)

This PR aims to fix all the mentioned issues