### PR TITLE
Porting the fastvdma to Chisel 6 (sbt version)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,5 @@ jobs:
           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
           curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
           sudo apt update && sudo apt install -y sbt
+          sudo apt-get update -y && sudo apt-get install -y verilator
           make testall

--- a/.gitignore
+++ b/.gitignore
@@ -340,8 +340,9 @@ hs_err_pid*
 
 # chisel output
 *.v
+*.sv
 *.fir
 *.anno.json
 
 *.rgba
-out.png
+out*.png

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,5 @@
 // See README.md for license details.
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
 def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   Seq() ++ {
     // Scala 2.12 requires Java 8. We continue to generate
@@ -28,30 +16,34 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 name := "chisel-dma"
 
-version := "3.5.3"
+version := "6.0.0"
 
-scalaVersion := "2.12.13"
-
-crossScalaVersions := Seq("2.11.12", "2.12.13")
+scalaVersion := "2.13.12"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")
 )
-// Chisel 3.5
-addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.3" cross CrossVersion.full)
+resolvers -= DefaultMavenRepository
+resolvers += "Maven Repo" at "https://mvnrepository.com/artifacts"
+
+// Chisel 6.0.0
+addCompilerPlugin("org.chipsalliance" % "chisel-plugin" % "6.0.0" cross CrossVersion.full)
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.5.+",
-  "chiseltest" -> "0.5.0",
-  "chisel-iotesters" -> "2.5.5+"
-  )
-libraryDependencies ++= Seq("chisel3","chiseltest","chisel-iotesters").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
+  "chisel" -> "6.0.0",
+  "chiseltest" -> "6.0-SNAPSHOT"
+)
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.8.+"
+val defaultOrgs = Map(
+  "chisel" -> "org.chipsalliance",
+  "chiseltest" -> "edu.berkeley.cs"
+)
 
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
+libraryDependencies ++= Seq("chisel","chiseltest").map {
+  dep: String => defaultOrgs(dep) %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
+
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.10.5"
 
 javacOptions ++= javacOptionsVersion(scalaVersion.value)

--- a/src/main/scala/DMAController/Bus/WishboneMaster.scala
+++ b/src/main/scala/DMAController/Bus/WishboneMaster.scala
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 package DMAController.Bus
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.log2Ceil
 
 class WishboneMaster(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   /* data */

--- a/src/main/scala/DMAController/Bus/WishboneSlave.scala
+++ b/src/main/scala/DMAController/Bus/WishboneSlave.scala
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 package DMAController.Bus
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.log2Ceil
 
 class WishboneSlave(val addrWidth : Int, val dataWidth : Int) extends Bundle{
   /* data */

--- a/src/main/scala/DMAController/CSR/ClearCSR.scala
+++ b/src/main/scala/DMAController/CSR/ClearCSR.scala
@@ -13,9 +13,9 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 package DMAController.CSR
-import DMAController.DMADriver
-import DMAUtils.DMAModule
+
 import chisel3._
+import DMAUtils.DMAModule
 import DMAController.DMAConfig.DMAConfig
 
 class ClearCSR(dmaConfig: DMAConfig) extends DMAModule(dmaConfig) {

--- a/src/main/scala/DMAController/CSR/SetCSR.scala
+++ b/src/main/scala/DMAController/CSR/SetCSR.scala
@@ -16,7 +16,6 @@ package DMAController.CSR
 
 import chisel3._
 import DMAUtils.DMAModule
-import DMAController.DMADriver
 import DMAController.DMAConfig._
 
 class SetCSR(dmaConfig: DMAConfig) extends DMAModule(dmaConfig) {

--- a/src/main/scala/DMAController/CSR/SimpleCSR.scala
+++ b/src/main/scala/DMAController/CSR/SimpleCSR.scala
@@ -16,7 +16,6 @@ package DMAController.CSR
 
 import chisel3._
 import DMAUtils.DMAModule
-import DMAController.DMADriver
 import DMAController.DMAConfig._
 
 class SimpleCSR(config: DMAConfig) extends DMAModule(config) {

--- a/src/main/scala/DMAController/CSR/StatusCSR.scala
+++ b/src/main/scala/DMAController/CSR/StatusCSR.scala
@@ -14,9 +14,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.CSR
 
-import DMAUtils.DMAModule
-import DMAController.DMADriver
 import chisel3._
+import DMAUtils.DMAModule
 import DMAController.DMAConfig._
 
 class StatusCSR(dmaConfig: DMAConfig) extends DMAModule(dmaConfig){

--- a/src/main/scala/DMAController/DMAConfig.scala
+++ b/src/main/scala/DMAController/DMAConfig.scala
@@ -15,11 +15,6 @@ SPDX-License-Identifier: Apache-2.0
 package DMAController.DMAConfig
 
 import chisel3._
-import DMAController.Bus._
-import DMAController.CSR.CSR
-import DMAController.Frontend._
-import DMAController.Worker.{InterruptBundle, WorkerCSRWrapper, SyncBundle}
-import chisel3.util.Queue
 
 class DMAConfig(
     val busConfig: String = "AXI_AXIL_AXI",

--- a/src/main/scala/DMAController/DMADriver.scala
+++ b/src/main/scala/DMAController/DMADriver.scala
@@ -14,10 +14,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import DMAConfig._
 import DMAUtils.{DMAParseInput, DMALogger}
-import DMAController.DMAConfig._
 
 object DMADriver extends App {
   val config =
@@ -36,5 +35,5 @@ object DMADriver extends App {
       }
     }
 
-  (new ChiselStage).emitVerilog(new DMATop(config))
+  ChiselStage.emitSystemVerilogFile(new DMATop(config))
 }

--- a/src/main/scala/DMAController/DMATop.scala
+++ b/src/main/scala/DMAController/DMATop.scala
@@ -15,8 +15,6 @@ SPDX-License-Identifier: Apache-2.0
 package DMAController
 
 import chisel3._
-import chisel3.util._
-import DMAController.Bus._
 import DMAController.CSR._
 import DMAController.Frontend._
 import DMAController.Worker.{InterruptBundle, WorkerCSRWrapper, SyncBundle}

--- a/src/main/scala/DMAController/Frontend/AXI4LiteCSR.scala
+++ b/src/main/scala/DMAController/Frontend/AXI4LiteCSR.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.AXI4Lite
-import DMAController.CSR.{CSR, CSRBusBundle}
-import DMAController.Worker.{WorkerCSRWrapper}
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.AXI4Lite
+import DMAController.CSR.CSRBusBundle
+import DMAController.DMAConfig.DMAConfig
 
 class AXI4LiteCSR(addrWidth: Int, dataWidth: Int, regCount: Int,
     dmaConfig: DMAConfig) extends CSRBus[AXI4Lite](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/AXI4LiteWriter.scala
+++ b/src/main/scala/DMAController/Frontend/AXI4LiteWriter.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus._
-import DMAController.Worker.{WorkerCSRWrapper, XferDescBundle}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus._
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class AXI4LiteWriter(val addrWidth: Int, val dataWidth: Int,
   dmaConfig: DMAConfig) extends IOBus[AXI4Lite](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/AXI4Reader.scala
+++ b/src/main/scala/DMAController/Frontend/AXI4Reader.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus._
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
+import DMAController.Bus._
 import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class AXI4Reader(val addrWidth: Int, val dataWidth: Int, dmaConfig: DMAConfig)
     extends IOBus[AXI4](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/AXI4Writer.scala
+++ b/src/main/scala/DMAController/Frontend/AXI4Writer.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus._
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus._
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class AXI4Writer(val addrWidth: Int, val dataWidth: Int, dmaConfig: DMAConfig)
     extends IOBus[AXI4](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/AXIStreamMaster.scala
+++ b/src/main/scala/DMAController/Frontend/AXIStreamMaster.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.AXIStream
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.AXIStream
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class AXIStreamMaster(val addrWidth: Int, val dataWidth: Int, dmaConfig: DMAConfig)
     extends IOBus[AXIStream](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/AXIStreamSlave.scala
+++ b/src/main/scala/DMAController/Frontend/AXIStreamSlave.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.AXIStream
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.AXIStream
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class AXIStreamSlave(val addrWidth: Int, val dataWidth: Int, dmaConfig: DMAConfig)
     extends IOBus[AXIStream](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/BusBase.scala
+++ b/src/main/scala/DMAController/Frontend/BusBase.scala
@@ -13,14 +13,14 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 package DMAController.Frontend
-import DMAController.Bus._
-import DMAController.CSR.{CSR, CSRBusBundle}
-import DMAController.Worker.{WorkerCSRWrapper, XferDescBundle}
-import DMAUtils.DMAModule
+
 import chisel3._
 import chisel3.util._
-import DMAController.DMADriver
-import DMAController.DMAConfig._
+import DMAUtils.DMAModule
+import DMAController.Bus._
+import DMAController.CSR.CSRBusBundle
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 abstract class IOBus[+T](config: DMAConfig) extends DMAModule(config) {
   val io : Bundle {

--- a/src/main/scala/DMAController/Frontend/WishboneCSR.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneCSR.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.WishboneSlave
-import DMAController.CSR.{CSR, CSRBusBundle}
-import DMAController.Worker.WorkerCSRWrapper
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.CSR.CSRBusBundle
+import DMAController.Bus.WishboneSlave
+import DMAController.DMAConfig.DMAConfig
 
 class WishboneCSR(addrWidth: Int, dataWidth: Int, regCount: Int,
     dmaConfig: DMAConfig) extends CSRBus[WishboneSlave](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedReader.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedReader.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.WishboneMaster
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
 import DMAController.DMAConfig._
+import DMAController.Bus.WishboneMaster
+import DMAController.Worker.XferDescBundle
 
 class WishboneClassicPipelinedReader(val addrWidth: Int, val dataWidth: Int,
     config: DMAConfig) extends IOBus[WishboneMaster](config) {

--- a/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedWriter.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicPipelinedWriter.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.WishboneMaster
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.WishboneMaster
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class WishboneClassicPipelinedWriter(val addrWidth: Int, val dataWidth: Int,
     dmaConfig: DMAConfig) extends IOBus[WishboneMaster](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicReader.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.WishboneMaster
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.WishboneMaster
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class WishboneClassicReader(val addrWidth: Int, val dataWidth: Int,
     dmaConfig: DMAConfig) extends IOBus[WishboneMaster](dmaConfig) {

--- a/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
+++ b/src/main/scala/DMAController/Frontend/WishboneClassicWriter.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Frontend
 
-import DMAController.Bus.WishboneMaster
-import DMAController.Worker.{XferDescBundle, WorkerCSRWrapper}
-import DMAController.CSR.CSR
 import chisel3._
 import chisel3.util._
-import DMAController.DMAConfig._
+import DMAController.Bus.WishboneMaster
+import DMAController.DMAConfig.DMAConfig
+import DMAController.Worker.XferDescBundle
 
 class WishboneClassicWriter(val addrWidth: Int, val dataWidth: Int,
     dmaConfig: DMAConfig) extends IOBus[WishboneMaster](dmaConfig) {

--- a/src/main/scala/DMAController/Worker/AddressGenerator.scala
+++ b/src/main/scala/DMAController/Worker/AddressGenerator.scala
@@ -17,8 +17,7 @@ package DMAController.Worker
 import chisel3._
 import chisel3.util._
 import DMAUtils.DMAModule
-import DMAController.DMAConfig._
-import DMAController.DMATop
+import DMAController.DMAConfig.DMAConfig
 
 class AddressGenerator(val addrWidth: Int, val dataWidth: Int,
     dmaConfig: DMAConfig) extends DMAModule(dmaConfig) {

--- a/src/main/scala/DMAController/Worker/InterruptController.scala
+++ b/src/main/scala/DMAController/Worker/InterruptController.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Worker
 
-import DMAController.CSR.{CSRRegBundle, SetCSR, SimpleCSR}
 import chisel3._
 import chisel3.util.Cat
 import DMAUtils.DMAModule
-import DMAController.DMADriver
-import DMAController.DMAConfig._
+import DMAController.CSR._
+import DMAController.DMAConfig.DMAConfig
 
 class InterruptController(dmaConfig: DMAConfig) extends DMAModule(dmaConfig) {
   val io = IO(new Bundle {

--- a/src/main/scala/DMAController/Worker/TransferSplitter.scala
+++ b/src/main/scala/DMAController/Worker/TransferSplitter.scala
@@ -17,8 +17,7 @@ package DMAController.Worker
 import chisel3._
 import chisel3.util._
 import DMAUtils.DMAModule
-import DMAController.DMAConfig._
-import DMAController.DMADriver
+import DMAController.DMAConfig.DMAConfig
 
 class TransferSplitter(val addressWidth: Int, val dataWidth: Int,
     val maxLength: Int, val canCrossBarrier: Boolean, dmaConfig: DMAConfig

--- a/src/main/scala/DMAController/Worker/WorkerCSRWrapper.scala
+++ b/src/main/scala/DMAController/Worker/WorkerCSRWrapper.scala
@@ -14,11 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Worker
 
-import DMAController.CSR._
-import DMAController.DMAConfig._
-import DMAUtils._
 import chisel3._
 import chisel3.util.Cat
+import DMAUtils._
+import DMAController.CSR._
+import DMAController.DMAConfig._
 
 class WorkerCSRWrapper(cfg: DMAConfig) extends DMAModule(cfg) {
   val io = IO(new Bundle {
@@ -51,7 +51,7 @@ class WorkerCSRWrapper(cfg: DMAConfig) extends DMAModule(cfg) {
   val clear = Wire(UInt())
 
   val envTag = System.getenv("TAG")
-  val tag = if (envTag.isEmpty()) "v0.0" else envTag
+  val tag = Option(envTag).filter(_.nonEmpty).getOrElse("v0.0")
   val version = RegInit(tag.filter(_.isDigit).toInt.U)
   val (in, csr, out) = cfg.getBusConfig()
   val encConfig = RegInit((in << 8 | csr << 4 | out).U(cfg.addrWidth.W))

--- a/src/main/scala/DMAUtils/DMAUtils.scala
+++ b/src/main/scala/DMAUtils/DMAUtils.scala
@@ -3,7 +3,7 @@ package DMAUtils
 import chisel3._
 import chisel3.util._
 import play.api.libs.json._
-import java.io.{FileNotFoundException, IOException}
+import java.io.FileNotFoundException
 import DMAController.DMAConfig._
 
 abstract class DMAModule(config: DMAConfig) extends Module {
@@ -117,7 +117,7 @@ object DMAQueue {
         q.io.enq.valid := enq.valid
         q.io.enq.bits := enq.bits
         enq.ready := q.io.enq.ready
-        TransitName(q.io.deq, q)
+        q.io.deq
       }
     }
 }

--- a/src/test/scala/DMAController/Bfm/Axi4SlaveBfm.scala
+++ b/src/test/scala/DMAController/Bfm/Axi4SlaveBfm.scala
@@ -14,10 +14,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Bfm
 
-import DMAController.Bus._
-import chisel3.Bits
-
 import java.nio._
+import chisel3.Bits
+import DMAController.Bus._
 
 class Axi4MemoryBfm(val axi: AXI4,
                         val size: Int,
@@ -101,7 +100,7 @@ extends Axi4Bfm {
           }
         }
       }
-      peekInputs
+      peekInputs()
     }
   }
 
@@ -162,7 +161,7 @@ extends Axi4Bfm {
           }
         }
       }
-      peekInputs
+      peekInputs()
     }
   }
 

--- a/src/test/scala/DMAController/Bfm/AxiLiteMasterBfm.scala
+++ b/src/test/scala/DMAController/Bfm/AxiLiteMasterBfm.scala
@@ -24,10 +24,10 @@ SOFTWARE.
 */
 package DMAController.Bfm
 
-import DMAController.Bus._
-import chisel3.Bits
-
 import scala.collection.mutable.ListBuffer
+
+import chisel3.Bits
+import DMAController.Bus._
 
 /**
   * Bus functional model for AXI Lite master
@@ -118,7 +118,7 @@ class AxiLiteMasterBfm(val axi: AXI4Lite,
         }
       }
 
-      peekInputs
+      peekInputs()
     }
   }
 
@@ -193,7 +193,7 @@ class AxiLiteMasterBfm(val axi: AXI4Lite,
         }
       }
 
-      peekInputs
+      peekInputs()
     }
   }
 
@@ -201,8 +201,9 @@ class AxiLiteMasterBfm(val axi: AXI4Lite,
   // queues
   class Cmd(val is_read: Boolean, val addr: BigInt, val wr_data: BigInt)
   class Resp(val success: Boolean, val rd_data: BigInt)
-  private var cmdList: ListBuffer[Cmd] = new ListBuffer()
-  private var respList: ListBuffer[Resp] = new ListBuffer()
+
+  private val cmdList: ListBuffer[Cmd] = new ListBuffer()
+  private val respList: ListBuffer[Resp] = new ListBuffer()
 
   // interfaces
   private val read_if = new ReadIf()

--- a/src/test/scala/DMAController/Bfm/AxiStreamMasterBfm.scala
+++ b/src/test/scala/DMAController/Bfm/AxiStreamMasterBfm.scala
@@ -14,12 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Bfm
 
-import DMAController.Bus._
-import chisel3.Bits
-
 import java.nio._
-
 import scala.collection.mutable.ListBuffer
+
+import chisel3.Bits
+import DMAController.Bus._
 
 class AxiStreamMasterBfm(val axi: AXIStream,
                         val packetLen: Int,
@@ -28,7 +27,7 @@ class AxiStreamMasterBfm(val axi: AXIStream,
                         val println: String => Unit) 
 extends AxiStreamBfm {
 
-  private var txList: ListBuffer[Int] = new ListBuffer()
+  private val txList: ListBuffer[Int] = new ListBuffer()
 
   private object State extends Enumeration {
     type State = Value
@@ -45,8 +44,7 @@ extends AxiStreamBfm {
     val path = file.Paths.get(filename)
     val buffer = file.Files.readAllBytes(path)
     val bb = ByteBuffer.wrap(buffer)
-    //bb.order(ByteOrder.nativeOrder)
-    var buf = new Array[Int](buffer.length/4)
+    val buf = new Array[Int](buffer.length / 4)
     bb.asIntBuffer.get(buf)
     for(i <- 0 until buf.length) {
       txList += buf(i)
@@ -79,15 +77,15 @@ extends AxiStreamBfm {
         if(txList.nonEmpty) {
           poke(axi.tvalid, 1)
           state = State.WriteData
-          putData
-          updateTlast
+          putData()
+          updateTlast()
         }
       }
       case State.WriteData => {
         if(tready != 0) {
           if(txList.nonEmpty) {
-            putData
-            updateTlast
+            putData()
+            updateTlast()
             if(wordCnt == packetLen) {
               wordCnt = 0
             } else {
@@ -100,6 +98,6 @@ extends AxiStreamBfm {
         }
       }
     }
-    peekInputs
+    peekInputs()
   }
 }

--- a/src/test/scala/DMAController/Bfm/AxiStreamSlaveBfm.scala
+++ b/src/test/scala/DMAController/Bfm/AxiStreamSlaveBfm.scala
@@ -14,10 +14,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Bfm
 
-import DMAController.Bus._
-import chisel3.Bits
-
 import scala.collection.mutable.ListBuffer
+
+import chisel3.Bits
+import DMAController.Bus._
 
 class AxiStreamSlaveBfm(val axi: AXIStream,
                         val peek: Bits => BigInt,
@@ -25,7 +25,7 @@ class AxiStreamSlaveBfm(val axi: AXIStream,
                         val println: String => Unit)
 extends AxiStreamBfm {
 
-  private var rxList: ListBuffer[BigInt] = new ListBuffer()
+  private val rxList: ListBuffer[BigInt] = new ListBuffer()
 
   private object State extends Enumeration {
     type State = Value
@@ -58,7 +58,7 @@ extends AxiStreamBfm {
         }
       }
     }
-    peekInputs
+    peekInputs()
   }
 
   def loadFromFile(filename: String): Unit = {

--- a/src/test/scala/DMAController/ComponentSpec.scala
+++ b/src/test/scala/DMAController/ComponentSpec.scala
@@ -14,19 +14,17 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import DMAController.Frontend._
-import DMAController.Worker._
-import org.scalatest.{FlatSpec, Matchers}
 import chisel3._
 import chiseltest._
 import chiseltest.iotesters._
-import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.flatspec.AnyFlatSpec
-import DMAController.DMAConfig._
+import DMAController.Worker._
+import DMAController.Frontend._
+import DMAController.DMAConfig.DMAConfig
 
 class ComponentSpec extends AnyFlatSpec with ChiselScalatestTester {
   val cfg = new DMAConfig("AXI_AXIL_AXI")
-  val testAnnotations = Seq(WriteVcdAnnotation)
+  val testAnnotations = Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)
 
   def testFastVDMAComponent[T <: Module](
       dutGen: => T,

--- a/src/test/scala/DMAController/ControllerSpec.scala
+++ b/src/test/scala/DMAController/ControllerSpec.scala
@@ -14,17 +14,16 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import chiseltest.ChiselScalatestTester
+import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 import DMAController.DMAConfig._
-import chiseltest._
 
 class ControllerSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "ControllerSpec"
   val dmaConfigMM2MM = new DMAConfig("AXI_AXIL_AXI")
   it should "perform 2D MM2MM transfer with stride mem to mem" in {
     test(new DMATop(dmaConfigMM2MM))
-      .withAnnotations(Seq(WriteVcdAnnotation))
+      .withAnnotations(Seq(VerilatorBackendAnnotation))
       .runPeekPoke(dut =>
         new ImageTransfer(dut, new DMAFullMem(dut), dmaConfigMM2MM)
       )
@@ -33,7 +32,7 @@ class ControllerSpec extends AnyFlatSpec with ChiselScalatestTester {
   val dmaConfigS2MM = new DMAConfig("AXIS_AXIL_AXI")
   it should "perform 2D S2MM transfer with stride stream to mem" in {
     test(new DMATop(dmaConfigS2MM))
-      .withAnnotations(Seq(WriteVcdAnnotation))
+      .withAnnotations(Seq(VerilatorBackendAnnotation))
       .runPeekPoke(dut =>
         new ImageTransfer(dut, new DMAFullStream(dut), dmaConfigS2MM)
       )

--- a/src/test/scala/DMAController/DMAFull.scala
+++ b/src/test/scala/DMAController/DMAFull.scala
@@ -14,9 +14,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import DMAController.Bfm.{ControlBfm, IOBfm}
-import DMAController.Worker.{InterruptBundle, SyncBundle}
 import chiseltest.iotesters.PeekPokeTester
+import DMAController.Bfm.{ControlBfm, IOBfm}
 
 abstract class DMAFull(dut: DMATop) extends PeekPokeTester(dut){
   val control: ControlBfm

--- a/src/test/scala/DMAController/DMAFullMem.scala
+++ b/src/test/scala/DMAController/DMAFullMem.scala
@@ -14,20 +14,21 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
+import chisel3.{Bits, Bundle}
 import DMAController.Bfm.{AxiLiteMasterBfm, Axi4MemoryBfm}
 import DMAController.Bus.{AXI4Lite, AXI4}
 import DMAController.Worker.{InterruptBundle, SyncBundle}
-import chisel3.{Bits, Bundle}
 
 class DMAFullMem(dut: DMATop) extends DMAFull(dut) {
   val width = 256
   val height = 256
   val io = dut.io.asInstanceOf[Bundle{
-                                val control: AXI4Lite
-                                val read: AXI4
-                                val write: AXI4
-                                val irq: InterruptBundle
-                                val sync: SyncBundle}]
+    val control: AXI4Lite
+    val read: AXI4
+    val write: AXI4
+    val irq: InterruptBundle
+    val sync: SyncBundle
+  }]
 
   val control = new AxiLiteMasterBfm(io.control, peek[Bits], poke[Bits], println)
   val reader = new Axi4MemoryBfm(io.read, width * height, peek[Bits], poke[Bits], println)

--- a/src/test/scala/DMAController/DMAFullStream.scala
+++ b/src/test/scala/DMAController/DMAFullStream.scala
@@ -14,20 +14,21 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import DMAController.Bfm.{AxiLiteMasterBfm, AxiStreamMasterBfm, Axi4MemoryBfm}
+import chisel3.{Bits, Bundle}
 import DMAController.Bus.{AXI4Lite, AXIStream, AXI4}
 import DMAController.Worker.{InterruptBundle, SyncBundle}
-import chisel3.{Bits, Bundle}
+import DMAController.Bfm.{AxiLiteMasterBfm, AxiStreamMasterBfm, Axi4MemoryBfm}
 
 class DMAFullStream(dut: DMATop) extends DMAFull(dut) {
   val width = 256
   val height = 256
   val io = dut.io.asInstanceOf[Bundle{
-                                val control: AXI4Lite
-                                val read: AXIStream
-                                val write: AXI4
-                                val irq: InterruptBundle
-                                val sync: SyncBundle}]
+    val control: AXI4Lite
+    val read: AXIStream
+    val write: AXI4
+    val irq: InterruptBundle
+    val sync: SyncBundle
+  }]
 
   val control = new AxiLiteMasterBfm(io.control, peek[Bits], poke[Bits], println)
   val reader = new AxiStreamMasterBfm(io.read, width * height, peek[Bits], poke[Bits], println)

--- a/src/test/scala/DMAController/ImageTransfer.scala
+++ b/src/test/scala/DMAController/ImageTransfer.scala
@@ -14,10 +14,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController
 
-import DMAController.Bfm.ChiselBfm
-import DMAController.Worker.{InterruptBundle, SyncBundle}
+import chisel3._
 import chiseltest.iotesters.PeekPokeTester
-import chisel3.Bits
 import DMAController.DMAConfig._
 
 class ImageTransfer(dut: DMATop, dmaFull: DMAFull, dmaConfig: DMAConfig) extends PeekPokeTester(dut){
@@ -27,10 +25,10 @@ class ImageTransfer(dut: DMATop, dmaFull: DMAFull, dmaConfig: DMAConfig) extends
   val max = width * height * 2
   var cnt: Int = 0
 
-  def waitRange(data: Bits, exp: Int, min: Int, max: Int) : Unit = {
+  def waitRange(data: Bits, exp: Int, min: Int, max: Int): Unit = {
     var cnt = 0
 
-    while(peek(data) != exp && cnt < max){
+    while (peek(data) != exp && cnt < max) {
       step(1)
       cnt += 1
     }
@@ -51,8 +49,8 @@ class ImageTransfer(dut: DMATop, dmaFull: DMAFull, dmaConfig: DMAConfig) extends
   }
 
   override def step(n: Int): Unit = {
-    for(_ <- 0 until n) {
-      stepSingle
+    for (_ <- 0 until n) {
+      stepSingle()
     }
   }
 

--- a/src/test/scala/DMAController/TestUtil.scala
+++ b/src/test/scala/DMAController/TestUtil.scala
@@ -14,14 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.TestUtil
 
-import chisel3.iotesters._
-
 object WaitRange {
   def waitRange(init: Int, max: Int, cond: () => Boolean): Boolean = {
     for(i <- init to max) {
-      if (cond())
-        return true
+      if (cond()) return true
     }
-    return false
+    false
   }
 }

--- a/src/test/scala/DMAController/Worker/AddressGeneratorTest.scala
+++ b/src/test/scala/DMAController/Worker/AddressGeneratorTest.scala
@@ -14,7 +14,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package DMAController.Worker
 
-//import chisel3.iotesters._
 import chiseltest.iotesters.PeekPokeTester
 
 class AddressGeneratorTest(dut : AddressGenerator) extends PeekPokeTester(dut) {


### PR DESCRIPTION
Changes:
- Ported code from chisel 3.5.6 to chisel 6.0.0
- Added verilator installation to github workflow 

I just saw that there is open PR for porting to design to chisel 6 from [kammoh](https://github.com/kammoh) but since it is not yet resolved I have decided to open the PR nevertheless.

Code wise, there are no much difference between old chisel version and the new one. Only things that I really needed to change are [here](https://github.com/pznikola/fastvdma/blob/main/src/main/scala/DMAController/Worker/WorkerCSRWrapper.scala#L54) and [here](https://github.com/pznikola/fastvdma/blob/038df8b214d512900de493e84a6d8d85b456096d/src/main/scala/DMAUtils/DMAUtils.scala#L120). Other changes are mostly cosmetic ones.

The Verilator installation for the CI check is added in order for testing to pass (CI flow was failing due to the verilator missing). Maybe this was not necessary.

